### PR TITLE
Fix incorrect import path in diffusers

### DIFF
--- a/src/semdiffusers/pipeline_latent_edit_diffusion.py
+++ b/src/semdiffusers/pipeline_latent_edit_diffusion.py
@@ -9,7 +9,7 @@ from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
 
 from diffusers.configuration_utils import FrozenDict
 from diffusers.models import AutoencoderKL, UNet2DConditionModel
-from diffusers.pipeline_utils import DiffusionPipeline
+from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 from diffusers.pipelines.stable_diffusion.safety_checker import StableDiffusionSafetyChecker
 from diffusers.schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler
 from diffusers.utils import deprecate, logging


### PR DESCRIPTION
This commit corrects the import path from 'diffusers.pipeline_utils' to 'diffusers.pipelines.pipeline_utils' to align with the latest changes in the diffusers library. This update resolves the import error when using the external library in projects.
